### PR TITLE
change license to licence

### DIFF
--- a/client/src/app/+videos/+video-edit/shared/video-edit.component.html
+++ b/client/src/app/+videos/+video-edit/shared/video-edit.component.html
@@ -76,7 +76,7 @@
               <my-help>
                 <ng-template ptTemplate="customHtml">
                   <ng-container i18n>
-                    <a href="https://chooser-beta.creativecommons.org/" target="_blank" rel="noopener noreferrer">Choose</a> the appropriate license for your work.
+                    <a href="https://chooser-beta.creativecommons.org/" target="_blank" rel="noopener noreferrer">Choose</a> the appropriate licence for your work.
                   </ng-container>
                 </ng-template>
               </my-help>


### PR DESCRIPTION
Change "license" to "licence" for consistency in the user interface in English. 

License is both a noun and a verb in the United States.
If you live in any other English-speaking country, you will spell it "licence" when you use it as a noun and "license" when you use it as a verb.